### PR TITLE
refactor!: update naming of access utils and all types

### DIFF
--- a/src/fare-contract/__tests__/availability-status.test.ts
+++ b/src/fare-contract/__tests__/availability-status.test.ts
@@ -1,8 +1,8 @@
 import {
-  UsedAccess,
-  FareContract,
+  UsedAccessType,
+  FareContractType,
   FareContractState,
-  TravelRight,
+  TravelRightType,
 } from '../types';
 import {getAvailabilityStatus} from '../availability-status';
 import {addMinutes} from './test-utils';
@@ -15,12 +15,12 @@ import {addMinutes} from './test-utils';
  */
 const createFareContract = (args?: {
   state?: FareContractState;
-  travelRights?: TravelRight[];
-}): FareContract => {
+  travelRights?: TravelRightType[];
+}): FareContractType => {
   return {
     state: args?.state === undefined ? FareContractState.Activated : args.state,
     travelRights: args?.travelRights ?? [createTravelRight()],
-  } as FareContract;
+  } as FareContractType;
 };
 
 /**
@@ -36,11 +36,11 @@ const createTravelRight = (
   } & (
     | {}
     | {
-        usedAccesses: UsedAccess[];
+        usedAccesses: UsedAccessType[];
         maximumNumberOfAccesses: number;
       }
   ),
-): TravelRight => {
+): TravelRightType => {
   const travelRight: any = {
     startDateTime: args?.startTime ?? addMinutes(new Date(), -60),
     endDateTime: args?.endTime ?? addMinutes(new Date(), 60),
@@ -50,7 +50,7 @@ const createTravelRight = (
     travelRight.numberOfUsedAccesses = args.usedAccesses.length;
     travelRight.usedAccesses = args.usedAccesses;
   }
-  return travelRight as TravelRight;
+  return travelRight as TravelRightType;
 };
 
 /**
@@ -59,7 +59,7 @@ const createTravelRight = (
 const createUsedAccess = (args?: {
   startTime?: Date;
   endTime?: Date;
-}): UsedAccess => {
+}): UsedAccessType => {
   return {
     startDateTime: args?.startTime ?? addMinutes(new Date(), -60),
     endDateTime: args?.endTime ?? addMinutes(new Date(), 60),

--- a/src/fare-contract/__tests__/fixtures/carnet-farecontact.ts
+++ b/src/fare-contract/__tests__/fixtures/carnet-farecontact.ts
@@ -1,6 +1,7 @@
+import {FareContractType} from '../../types';
 import {carnetTravelRight} from './carnet-travelright';
 
-export const carnetFareContract = {
+export const carnetFareContract: FareContractType = {
   paymentType: ['MASTERCARD'],
   state: 2,
   purchasedBy: 'ATB:CustomerAccount:Qw3fhcJudvgCYR7yHScbFd1mPtP2',

--- a/src/fare-contract/__tests__/fixtures/period-boat-farecontract.ts
+++ b/src/fare-contract/__tests__/fixtures/period-boat-farecontract.ts
@@ -1,6 +1,7 @@
+import {FareContractType} from '../../types';
 import {periodBoatTravelRight} from './period-boat-travelright';
 
-export const periodBoatFareContract = {
+export const periodBoatFareContract: FareContractType = {
   paymentType: ['MASTERCARD'],
   state: 2,
   purchasedBy: 'ATB:CustomerAccount:Qw3fhcJudvgCYR7yHScbFd1mPtP2',

--- a/src/fare-contract/__tests__/travelrights.test.ts
+++ b/src/fare-contract/__tests__/travelrights.test.ts
@@ -6,41 +6,40 @@ import {singleTravelRight} from './fixtures/single-travelright';
 import {singleBoatTravelRight} from './fixtures/single-boat-travelright';
 import {youthTravelRight} from './fixtures/youth-travelright';
 
-import {TravelRight} from '../types';
+import {TravelRightType} from '../types';
 import {getAccesses} from '../accesses';
 import {skoleskyssTravelRight} from './fixtures/skoleskyss-travelright';
+import {periodBoatFareContract} from './fixtures/period-boat-farecontract';
+import {carnetFareContract} from './fixtures/carnet-farecontact';
 
 describe('Travelright type', () => {
   it('all should resolve to normal', async () => {
-    expect(TravelRight.safeParse(nightTravelRight).success).toBe(true);
-    expect(TravelRight.safeParse(periodTravelRight).success).toBe(true);
+    expect(TravelRightType.safeParse(nightTravelRight).success).toBe(true);
+    expect(TravelRightType.safeParse(periodTravelRight).success).toBe(true);
     expect(
-      TravelRight.safeParse(periodBoatTravelRight as TravelRight).success,
+      TravelRightType.safeParse(periodBoatTravelRight as TravelRightType)
+        .success,
     ).toBe(true);
-    expect(TravelRight.safeParse(singleTravelRight).success).toBe(true);
+    expect(TravelRightType.safeParse(singleTravelRight).success).toBe(true);
     expect(
-      TravelRight.safeParse(singleBoatTravelRight as TravelRight).success,
+      TravelRightType.safeParse(singleBoatTravelRight as TravelRightType)
+        .success,
     ).toBe(true);
-    expect(TravelRight.safeParse(youthTravelRight).success).toBe(true);
-    expect(TravelRight.safeParse(carnetTravelRight).success).toBe(true);
+    expect(TravelRightType.safeParse(youthTravelRight).success).toBe(true);
+    expect(TravelRightType.safeParse(carnetTravelRight).success).toBe(true);
   });
 
   it('non carnets should not have flattened accesses', async () => {
-    expect(getAccesses([nightTravelRight])).toBe(undefined);
-    expect(getAccesses([periodTravelRight])).toBe(undefined);
-    expect(getAccesses([periodBoatTravelRight as TravelRight])).toBe(undefined);
-    expect(getAccesses([singleTravelRight])).toBe(undefined);
-    expect(getAccesses([singleBoatTravelRight as TravelRight])).toBe(undefined);
-    expect(getAccesses([youthTravelRight])).toBe(undefined);
+    expect(getAccesses(periodBoatFareContract)).toBe(undefined);
   });
 
   it('carnets should have flattened accesses', async () => {
-    expect(getAccesses([carnetTravelRight])).toBeDefined();
+    expect(getAccesses(carnetFareContract)).toBeDefined();
   });
 
   it('skoleskyss should not resolve to normal', async () => {
-    expect(TravelRight.safeParse(skoleskyssTravelRight as any).success).toBe(
-      false,
-    );
+    expect(
+      TravelRightType.safeParse(skoleskyssTravelRight as any).success,
+    ).toBe(false);
   });
 });

--- a/src/fare-contract/__tests__/travelrights.test.ts
+++ b/src/fare-contract/__tests__/travelrights.test.ts
@@ -7,7 +7,7 @@ import {singleBoatTravelRight} from './fixtures/single-boat-travelright';
 import {youthTravelRight} from './fixtures/youth-travelright';
 
 import {TravelRight} from '../types';
-import {flattenTravelRightAccesses} from '../travel-right-accesses';
+import {getAccesses} from '../accesses';
 import {skoleskyssTravelRight} from './fixtures/skoleskyss-travelright';
 
 describe('Travelright type', () => {
@@ -26,20 +26,16 @@ describe('Travelright type', () => {
   });
 
   it('non carnets should not have flattened accesses', async () => {
-    expect(flattenTravelRightAccesses([nightTravelRight])).toBe(undefined);
-    expect(flattenTravelRightAccesses([periodTravelRight])).toBe(undefined);
-    expect(
-      flattenTravelRightAccesses([periodBoatTravelRight as TravelRight]),
-    ).toBe(undefined);
-    expect(flattenTravelRightAccesses([singleTravelRight])).toBe(undefined);
-    expect(
-      flattenTravelRightAccesses([singleBoatTravelRight as TravelRight]),
-    ).toBe(undefined);
-    expect(flattenTravelRightAccesses([youthTravelRight])).toBe(undefined);
+    expect(getAccesses([nightTravelRight])).toBe(undefined);
+    expect(getAccesses([periodTravelRight])).toBe(undefined);
+    expect(getAccesses([periodBoatTravelRight as TravelRight])).toBe(undefined);
+    expect(getAccesses([singleTravelRight])).toBe(undefined);
+    expect(getAccesses([singleBoatTravelRight as TravelRight])).toBe(undefined);
+    expect(getAccesses([youthTravelRight])).toBe(undefined);
   });
 
   it('carnets should have flattened accesses', async () => {
-    expect(flattenTravelRightAccesses([carnetTravelRight])).toBeDefined();
+    expect(getAccesses([carnetTravelRight])).toBeDefined();
   });
 
   it('skoleskyss should not resolve to normal', async () => {

--- a/src/fare-contract/accesses.ts
+++ b/src/fare-contract/accesses.ts
@@ -1,14 +1,14 @@
-import {UsedAccess, FareContract} from './types';
+import {UsedAccessType, FareContractType} from './types';
 import {flatten, sumBy} from 'lodash';
 
-type FlattenedAccesses = {
-  usedAccesses: UsedAccess[];
+type AccessInfoType = {
+  usedAccesses: UsedAccessType[];
   maximumNumberOfAccesses: number;
   numberOfUsedAccesses: number;
 };
 export function getAccesses(
-  fareContract: FareContract,
-): FlattenedAccesses | undefined {
+  fareContract: FareContractType,
+): AccessInfoType | undefined {
   // If there are no accesses, return undefined
   if (!hasAccesses(fareContract)) return undefined;
 
@@ -33,7 +33,7 @@ export function getAccesses(
   };
 }
 
-export function hasAccesses(fareContract: FareContract) {
+export function hasAccesses(fareContract: FareContractType) {
   return fareContract.travelRights.some(
     (tr) => tr.maximumNumberOfAccesses !== undefined,
   );

--- a/src/fare-contract/accesses.ts
+++ b/src/fare-contract/accesses.ts
@@ -1,4 +1,4 @@
-import {UsedAccess, TravelRight} from './types';
+import {UsedAccess, FareContract} from './types';
 import {flatten, sumBy} from 'lodash';
 
 type FlattenedAccesses = {
@@ -6,22 +6,24 @@ type FlattenedAccesses = {
   maximumNumberOfAccesses: number;
   numberOfUsedAccesses: number;
 };
-export function flattenTravelRightAccesses(
-  travelRights: TravelRight[],
+export function getAccesses(
+  fareContract: FareContract,
 ): FlattenedAccesses | undefined {
   // If there are no accesses, return undefined
-  if (!hasTravelRightAccesses(travelRights)) return undefined;
+  if (!hasAccesses(fareContract)) return undefined;
 
-  const allUsedAccesses = travelRights.map((t) => t.usedAccesses ?? []);
+  const allUsedAccesses = fareContract.travelRights.map(
+    (t) => t.usedAccesses ?? [],
+  );
   const usedAccesses = flatten(allUsedAccesses).sort(
     (a, b) => a.startDateTime.getTime() - b.startDateTime.getTime(),
   );
   const maximumNumberOfAccesses = sumBy(
-    travelRights,
+    fareContract.travelRights,
     (t) => t.maximumNumberOfAccesses ?? 0,
   );
   const numberOfUsedAccesses = sumBy(
-    travelRights,
+    fareContract.travelRights,
     (t) => t.numberOfUsedAccesses ?? 0,
   );
   return {
@@ -31,6 +33,8 @@ export function flattenTravelRightAccesses(
   };
 }
 
-export function hasTravelRightAccesses(travelRights: TravelRight[]) {
-  return travelRights.some((tr) => tr.maximumNumberOfAccesses !== undefined);
+export function hasAccesses(fareContract: FareContract) {
+  return fareContract.travelRights.some(
+    (tr) => tr.maximumNumberOfAccesses !== undefined,
+  );
 }

--- a/src/fare-contract/availability-status.ts
+++ b/src/fare-contract/availability-status.ts
@@ -1,4 +1,4 @@
-import {type FareContract, FareContractState} from '.';
+import {type FareContractType, FareContractState} from '.';
 import {getAccesses} from './accesses';
 
 export type AvailabilityStatus =
@@ -15,7 +15,7 @@ export type AvailabilityStatus =
  * @see https://github.com/AtB-AS/docs-private/blob/main/terminology.md#ticketing
  */
 export const getAvailabilityStatus = (
-  fc: FareContract,
+  fc: FareContractType,
   now: number,
 ): AvailabilityStatus => {
   if (fc.state === FareContractState.Refunded) {
@@ -34,7 +34,7 @@ export const getAvailabilityStatus = (
     return {availability: 'invalid', status: 'invalid'};
   }
 
-  const flattenedAccesses = getAccesses(fc.travelRights);
+  const flattenedAccesses = getAccesses(fc);
   if (flattenedAccesses) {
     const {usedAccesses, maximumNumberOfAccesses, numberOfUsedAccesses} =
       flattenedAccesses;

--- a/src/fare-contract/availability-status.ts
+++ b/src/fare-contract/availability-status.ts
@@ -1,5 +1,5 @@
 import {type FareContract, FareContractState} from '.';
-import {flattenTravelRightAccesses} from './travel-right-accesses';
+import {getAccesses} from './accesses';
 
 export type AvailabilityStatus =
   | {availability: 'available'; status: 'upcoming' | 'valid'}
@@ -34,7 +34,7 @@ export const getAvailabilityStatus = (
     return {availability: 'invalid', status: 'invalid'};
   }
 
-  const flattenedAccesses = flattenTravelRightAccesses(fc.travelRights);
+  const flattenedAccesses = getAccesses(fc.travelRights);
   if (flattenedAccesses) {
     const {usedAccesses, maximumNumberOfAccesses, numberOfUsedAccesses} =
       flattenedAccesses;

--- a/src/fare-contract/index.ts
+++ b/src/fare-contract/index.ts
@@ -6,4 +6,4 @@ export {
   TravelRightDirection,
 } from './types';
 export {getAvailabilityStatus, AvailabilityStatus} from './availability-status';
-export {flattenTravelRightAccesses} from './travel-right-accesses';
+export {getAccesses} from './accesses';

--- a/src/fare-contract/index.ts
+++ b/src/fare-contract/index.ts
@@ -1,8 +1,8 @@
 export {
-  UsedAccess,
-  FareContract,
+  UsedAccessType,
+  FareContractType,
   FareContractState,
-  TravelRight,
+  TravelRightType,
   TravelRightDirection,
 } from './types';
 export {getAvailabilityStatus, AvailabilityStatus} from './availability-status';

--- a/src/fare-contract/types.ts
+++ b/src/fare-contract/types.ts
@@ -26,17 +26,17 @@ export enum TravelRightDirection {
  * For definition, see `UsedAccess` struct in ticket service
  * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/travel_right.rs
  */
-export const UsedAccess = z.object({
+export const UsedAccessType = z.object({
   startDateTime: z.date(),
   endDateTime: z.date(),
 });
-export type UsedAccess = z.infer<typeof UsedAccess>;
+export type UsedAccessType = z.infer<typeof UsedAccessType>;
 
 /**
  * For definitions, see `TravelRight` struct in ticket service
  * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/travel_right.rs
  */
-export const TravelRight = z.object({
+export const TravelRightType = z.object({
   id: z.string(),
   customerAccountId: z.string().optional(),
   status: z.nativeEnum(TravelRightStatus),
@@ -53,9 +53,9 @@ export const TravelRight = z.object({
   direction: z.nativeEnum(TravelRightDirection).optional(),
   maximumNumberOfAccesses: z.number().optional(),
   numberOfUsedAccesses: z.number().optional(),
-  usedAccesses: z.array(UsedAccess).optional(),
+  usedAccesses: z.array(UsedAccessType).optional(),
 });
-export type TravelRight = z.infer<typeof TravelRight>;
+export type TravelRightType = z.infer<typeof TravelRightType>;
 
 export enum FareContractState {
   Unspecified = 0,
@@ -71,7 +71,7 @@ export enum FareContractState {
  * For definition, see `FareContract` struct in ticket service
  * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/fare_contract.rs
  */
-export const FareContract = z.object({
+export const FareContractType = z.object({
   created: z.date(),
   id: z.string(),
   customerAccountId: z.string(),
@@ -82,8 +82,8 @@ export const FareContract = z.object({
   state: z.nativeEnum(FareContractState),
   totalAmount: z.string(),
   totalTaxAmount: z.string(),
-  travelRights: z.array(TravelRight).nonempty(),
+  travelRights: z.array(TravelRightType).nonempty(),
   version: z.string(),
   purchasedBy: z.string(),
 });
-export type FareContract = z.infer<typeof FareContract>;
+export type FareContractType = z.infer<typeof FareContractType>;


### PR DESCRIPTION
- Renames flattenTravelRightAccesses to getAccesses, and FlattenedAccesses to AccessInfoType
- Adds "Type" postfix to all types

https://github.com/AtB-AS/mittatb-app/pull/4994#pullrequestreview-2598034072