### PR TITLE
fix!: make purchasedBy optional

### DIFF
--- a/src/fare-contract/types.ts
+++ b/src/fare-contract/types.ts
@@ -84,6 +84,6 @@ export const FareContractType = z.object({
   totalTaxAmount: z.string(),
   travelRights: z.array(TravelRightType).nonempty(),
   version: z.string(),
-  purchasedBy: z.string(),
+  purchasedBy: z.string().optional(),
 });
 export type FareContractType = z.infer<typeof FareContractType>;


### PR DESCRIPTION
The `purchasedBy` field was added in January 2024, meaning that older tickets doesn't have this field in Firestore. This was also an inconsistency with the ticket service, that uses `Option<String>`.

ref. https://mittatb.slack.com/archives/C02EEG7D8EL/p1739458152616939?thread_ts=1739447708.031719&cid=C02EEG7D8EL