### PR TITLE
feat: coerce fare contract date strings to Date

### DIFF
--- a/src/fare-contract/__tests__/fixtures/travelright-string-date.ts
+++ b/src/fare-contract/__tests__/fixtures/travelright-string-date.ts
@@ -1,0 +1,16 @@
+export const travelRightStringDate = {
+  startDateTime: '2025-05-05T09:39:30.651Z',
+  endDateTime: '2025-05-05T09:39:30.651Z',
+  authorityRef: 'ATB:Authority:2',
+  customerAccountId: 'ATB:CustomerAccount:zozaUVuZmUZVC5UxGzJZiHmrTIz1',
+  status: 5,
+  usageValidityPeriodRef: '',
+  userProfileRef: 'ATB:UserProfile:8ee842e3',
+  type: 'PreActivatedSingleTicket',
+  fareProductRef: 'ATB:PreassignedFareProduct:8808c360',
+  id: 'ATB:CustomerPurchasePackage:4ed7cc65-7b12-4f55-92b0-859d2de03e0c',
+  endPointRef: 'NSR:StopPlace:40114',
+  startPointRef: 'NSR:StopPlace:74007',
+  fareZoneRefs: ['ATB:FareZone:10'],
+  tariffZoneRefs: ['ATB:TariffZone:1'],
+};

--- a/src/fare-contract/__tests__/travelrights.test.ts
+++ b/src/fare-contract/__tests__/travelrights.test.ts
@@ -11,6 +11,7 @@ import {getAccesses} from '../accesses';
 import {skoleskyssTravelRight} from './fixtures/skoleskyss-travelright';
 import {periodBoatFareContract} from './fixtures/period-boat-farecontract';
 import {carnetFareContract} from './fixtures/carnet-farecontact';
+import {travelRightStringDate} from './fixtures/travelright-string-date';
 
 describe('Travelright type', () => {
   it('all should resolve to normal', async () => {
@@ -41,5 +42,14 @@ describe('Travelright type', () => {
     expect(
       TravelRightType.safeParse(skoleskyssTravelRight as any).success,
     ).toBe(false);
+  });
+});
+
+describe('Travelright with string dates', () => {
+  it('should coerce string date to Date', () => {
+    const result = TravelRightType.safeParse(travelRightStringDate);
+    expect(result.success).toBe(true);
+    expect(result.data?.startDateTime.getFullYear() === 2025);
+    expect(result.data?.endDateTime.getFullYear() === 2025);
   });
 });

--- a/src/fare-contract/types.ts
+++ b/src/fare-contract/types.ts
@@ -27,8 +27,8 @@ export enum TravelRightDirection {
  * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/travel_right.rs
  */
 export const UsedAccessType = z.object({
-  startDateTime: z.date(),
-  endDateTime: z.date(),
+  startDateTime: z.coerce.date(),
+  endDateTime: z.coerce.date(),
 });
 export type UsedAccessType = z.infer<typeof UsedAccessType>;
 
@@ -41,8 +41,8 @@ export const TravelRightType = z.object({
   customerAccountId: z.string().optional(),
   status: z.nativeEnum(TravelRightStatus),
   fareProductRef: z.string(),
-  startDateTime: z.date(),
-  endDateTime: z.date(),
+  startDateTime: z.coerce.date(),
+  endDateTime: z.coerce.date(),
   usageValidityPeriodRef: z.string().optional(),
   userProfileRef: z.string().optional(),
   authorityRef: z.string(),
@@ -74,7 +74,7 @@ export enum FareContractState {
  * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/fare_contract.rs
  */
 export const FareContractType = z.object({
-  created: z.date(),
+  created: z.coerce.date(),
   id: z.string(),
   customerAccountId: z.string(),
   orderId: z.string(),


### PR DESCRIPTION
To support serialization of fare contracts, the zod schema needs to handle dates on a string format.

Docs: https://v3.zod.dev/?id=coercion-for-primitives

part of https://github.com/AtB-AS/kundevendt/issues/20780