### PR TITLE
fix: .optional() to .nullish() for some values

### DIFF
--- a/src/fare-contract/types.ts
+++ b/src/fare-contract/types.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {nullishToOptional} from "../utils";
+import {nullishToOptional} from '../utils';
 
 export enum TravelRightStatus {
   UNSPECIFIED = 0,
@@ -51,7 +51,10 @@ export const TravelRightType = z.object({
   fareZoneRefs: z.array(z.string()).optional(),
   startPointRef: z.string().nullish().transform(nullishToOptional),
   endPointRef: z.string().nullish().transform(nullishToOptional),
-  direction: z.nativeEnum(TravelRightDirection).nullish().transform(nullishToOptional),
+  direction: z
+    .nativeEnum(TravelRightDirection)
+    .nullish()
+    .transform(nullishToOptional),
   maximumNumberOfAccesses: z.number().optional(),
   numberOfUsedAccesses: z.number().optional(),
   usedAccesses: z.array(UsedAccessType).optional(),


### PR DESCRIPTION
When DatedServiceJourney is used the value for `startPointRef`, `endPointRef` and `direction` are `null` from Firestore, which means the entire FC is filtered out with the old schema. This fixes that. 