### PR TITLE
chore: On zod v4, v4 is already the default import

### DIFF
--- a/src/error-response.ts
+++ b/src/error-response.ts
@@ -1,4 +1,4 @@
-import {z} from 'zod/v4';
+import {z} from 'zod';
 
 /** https://github.com/AtB-AS/amp-rs/blob/main/amp-http/src/lib.rs */
 export const HttpError = z.object({

--- a/src/fare-contract/types.ts
+++ b/src/fare-contract/types.ts
@@ -1,4 +1,4 @@
-import {z} from 'zod/v4';
+import {z} from 'zod';
 import {nullishToOptional} from '../utils';
 
 export enum TravelRightStatus {

--- a/src/offers/ticket-offer.ts
+++ b/src/offers/ticket-offer.ts
@@ -1,4 +1,4 @@
-import {z} from 'zod/v4';
+import {z} from 'zod';
 import {nullishToOptional} from '../utils';
 
 /**


### PR DESCRIPTION
Always use just `zod`, as v4 is already the default export on v4.