### PR TITLE
feat!: use plain strings for global message contexts

### DIFF
--- a/src/global-messages/index.ts
+++ b/src/global-messages/index.ts
@@ -1,1 +1,1 @@
-export {createGlobalMessageSchema, GenericGlobalMessageType} from './types';
+export {GlobalMessageSchema, GlobalMessageType} from './types';

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -3,41 +3,23 @@ import {LanguageAndTextSchema} from '../common/language-and-text';
 import {Rule} from '../rules/types';
 import {AppPlatform} from '../common/app-platform';
 
-/**
- * Create a global message schema with a consumer specific context enum.
- *
- * @example
- * export enum GlobalMessageContextEnum {
- *   webOverview = 'web-overview',
- * }
- * const GlobalMessageContextSchema = z.enum(GlobalMessageContextEnum);
- * export const GlobalMessageSchema = createGlobalMessageSchema(
- *   GlobalMessageContextSchema,
- * );
- */
-export function createGlobalMessageSchema<ContextEnum extends z.ZodType>(
-  contextEnum: ContextEnum,
-) {
-  return z.object({
-    id: z.string(),
-    active: z.boolean(),
-    title: z.array(LanguageAndTextSchema).optional(),
-    body: z.array(LanguageAndTextSchema),
-    link: z.array(LanguageAndTextSchema).optional(),
-    linkText: z.array(LanguageAndTextSchema).optional(),
-    type: z.enum(['error', 'valid', 'info', 'warning']),
-    subtle: z.boolean().optional(),
-    context: z.array(contextEnum),
-    isDismissable: z.boolean().optional(),
-    appPlatforms: z.array(AppPlatform).optional(),
-    appVersionMin: z.string().optional(),
-    appVersionMax: z.string().optional(),
-    startDate: z.coerce.date().optional(),
-    endDate: z.coerce.date().optional(),
-    rules: z.array(Rule).optional(),
-  });
-}
+export const GlobalMessageSchema = z.object({
+  id: z.string(),
+  active: z.boolean(),
+  title: z.array(LanguageAndTextSchema).optional(),
+  body: z.array(LanguageAndTextSchema),
+  link: z.array(LanguageAndTextSchema).optional(),
+  linkText: z.array(LanguageAndTextSchema).optional(),
+  type: z.enum(['error', 'valid', 'info', 'warning']),
+  subtle: z.boolean().optional(),
+  context: z.array(z.string()).nonempty(),
+  isDismissable: z.boolean().optional(),
+  appPlatforms: z.array(AppPlatform).optional(),
+  appVersionMin: z.string().optional(),
+  appVersionMax: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  rules: z.array(Rule).optional(),
+});
 
-export type GenericGlobalMessageType<ContextEnum extends z.ZodType> = z.infer<
-  ReturnType<typeof createGlobalMessageSchema<ContextEnum>>
->;
+export type GlobalMessageType = z.infer<typeof GlobalMessageSchema>;


### PR DESCRIPTION
The previous approach was flawed in that e.g. `context: ["app-assistant", "web-overview"]` would fail to parse, because `"web-overview"` was unknown to the app, and `"app-assistant"` was unknown on web.

It would be possible to add filtering to the current solution, but I think it makes more sense to use plain strings instead, then letting consumers handle which contexts actually are actually displayed.